### PR TITLE
Flycheck support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ pure/position.hh
 pure/stack.hh
 pure/pure.pc
 pure/etc/pure-mode.el
-pure/etc/pure-mode.elc
+pure/etc/*.elc
 pure/test/*.diff
 purepad/Debug
 purepad/Release

--- a/pure/INSTALL
+++ b/pure/INSTALL
@@ -340,13 +340,14 @@ file is not needed for normal operation, but can be used to write C/C++
 extensions modules or embed Pure in your C/C++ applications.)
 
 In addition, if the presence of GNU Emacs was detected at configure time, then
-by default pure-mode.el and pure-mode.elc will be installed in the Emacs
-site-lisp directory. make tries to guess the proper location of the site-lisp
-directory, but if it guesses wrong or if you want to install in some custom
-location then you can also set the ``elispdir`` make variable accordingly. If
-you prefer, you can also disable the automatic installation of the elisp files
-by running configure with ``./configure --without-elisp``. (In that case, it's
-still possible to install the elisp files manually with ``make install-el
+by default pure-mode.el and pure-mode.elc (as well as the corresponding
+flycheck package) will be installed in the Emacs site-lisp directory. make
+tries to guess the proper location of the site-lisp directory, but if it
+guesses wrong or if you want to install in some custom location then you can
+also set the ``elispdir`` make variable accordingly. If you prefer, you can
+also disable the automatic installation of the elisp files by running
+configure with ``./configure --without-elisp``. (In that case, it's still
+possible to install the elisp files manually with ``make install-el
 install-elc``.)
 
 Similarly, if you have `GNU TeXmacs`_ on your system and configure can locate
@@ -527,7 +528,7 @@ Also, you can enable code folding by adding this to your .emacs:
    (require 'hideshow)
    (add-hook 'pure-mode-hook 'hs-minor-mode)
 
-These lines should come before the loading of Pure mode in your .emacs, so
+These lines should come *before* the loading of Pure mode in your .emacs, so
 that Pure mode can adjust accordingly.
 
 Once Emacs has been configured to load Pure mode, you can just run it with a
@@ -538,6 +539,47 @@ Pure file to check that it works, e.g.::
 The online help about Pure mode can be read with ``C-h m``. The Pure
 documentation can be accessed in Pure mode with ``C-c h``.
 
+Last but not least, support for flycheck_, the on-the-fly syntax checker is
+available through a separate flycheck-pure.el package, which can be enabled in
+your .emacs as follows:
+
+.. code-block:: scheme
+
+   (require 'flycheck-pure)
+   (eval-after-load 'flycheck
+     '(add-hook 'flycheck-mode-hook #'flycheck-pure-setup))
+
+You need to have flycheck_ installed to make this work (it's available in
+MELPA_). Also, the Pure interpreter needs to be in your ``PATH`` or flycheck
+will not be able to find it.
+
+.. _flycheck: http://www.flycheck.org
+.. _MELPA: https://melpa.org
+
+This is highly recommended, because flycheck will warn you about syntax
+errors, undeclared identifiers, etc. immediately -- anything which can be
+found without actually executing the program. flycheck does this by
+continually running ``pure --check`` on your program while you're editing it.
+By default, flycheck will flag both errors and warnings by invoking the Pure
+interpreter with the :option:`-w <pure -w>` option. If you only want to see
+real compilation errors, you can turn this off by setting the
+``flycheck-pure-warnings`` variable to ``nil``:
+
+.. code-block:: scheme
+
+   (setq flycheck-pure-warnings nil)
+
+Also note that flycheck will not run on a buffer unless you specifically
+enable it (in which case you'll see the ``FlyC`` indicator in the mode line).
+However, you can also enable flycheck globally so that it automatically runs
+in every buffer with a mode that has an associated checker. To these ends, add
+the following line to your .emacs:
+
+.. code-block:: scheme
+
+   (add-hook 'after-init-hook #'global-flycheck-mode)
+
+Please check the flycheck_ website for more information.
 
 TeXmacs Plugin
 ==============

--- a/pure/Makefile.in
+++ b/pure/Makefile.in
@@ -229,8 +229,8 @@ Makefile.in acinclude.m4 aclocal.m4 configure.ac configure config.h.in \
 config/config.guess config/config.sub config/install-sh \
 $(SOURCE) $(EXTRA_SOURCE) w3centities.c strptime.c pure.cc pure_norl.cc \
 pure_main.c pure.1 pure.txt install-docs.sh run-tests.in \
-run-test.in pure.pc.in \
-etc/pure-mode.el.in etc/pure.* etc/pure-*.xml etc/pure-highlight.lang \
+run-test.in pure.pc.in etc/pure-mode.el.in etc/flycheck-pure.el \
+etc/pure.* etc/pure-*.xml etc/pure-highlight.lang \
 debian/* \
 examples/COPYING examples/Makefile.in examples/*.pure examples/*.purerc \
 examples/*.c examples/*.f90 examples/libor/COPYING examples/libor/*.pure \
@@ -305,14 +305,18 @@ etc/pure-mode.el: Makefile etc/pure-mode.el.in
 	sed -e 's,@bindir\@,$(bindir),g' -e 's,@libdir\@,$(libdir),g' $(srcdir)/etc/pure-mode.el.in > etc/pure-mode.el.tmp
 	mv etc/pure-mode.el.tmp etc/pure-mode.el
 
-# create pure-mode.elc from pure-mode.el (this requires emacs)
+# create pure-mode.elc from pure-mode.el (and flycheck-pure.elc from
+# flycheck-pure.el; this requires emacs)
 
 ELC = $(EMACS) -q --no-site-file -batch -eval "(add-to-list 'load-path \".\")" -eval "(setq byte-compile-warnings '(callargs free-vars noruntime redefine))" -f batch-byte-compile
 
 etc/pure-mode.elc: etc/pure-mode.el
 	cd etc && $(ELC) pure-mode.el
 
-elc: etc/pure-mode.elc
+etc/flycheck-pure.elc: etc/flycheck-pure.el
+	cd etc && $(ELC) flycheck-pure.el
+
+elc: etc/pure-mode.elc etc/flycheck-pure.elc
 
 # generate the library documentation (this requires pure-doc)
 
@@ -331,7 +335,7 @@ install.txt: INSTALL
 # cleaning
 
 clean:
-	rm -f *~ *.bak pure$(EXE) $(OBJECT) pure.o pure_main.o $(libpure_lnkname) $(libpure_soname) $(libpure) parser.output etc/pure-mode.elc texmacs/plugins/pure/*/*~
+	rm -f *~ *.bak pure$(EXE) $(OBJECT) pure.o pure_main.o $(libpure_lnkname) $(libpure_soname) $(libpure) parser.output etc/pure-mode.elc etc/flycheck-pure.elc texmacs/plugins/pure/*/*~
 
 distclean: clean
 	rm -f Makefile config.h config.log config.status etc/pure-mode.el $(dist).tar.gz
@@ -400,7 +404,7 @@ endif
 	$(INSTALL) -m 644 $(srcdir)/pure.1 $(DESTDIR)$(man1dir)/$(pure_1)
 ifneq ($(elcfiles),)
 	$(INSTALL) -d $(DESTDIR)$(elispdir)
-	$(INSTALL) -m 644 etc/pure-mode.el etc/pure-mode.elc $(DESTDIR)$(elispdir)
+	$(INSTALL) -m 644 etc/pure-mode.el etc/pure-mode.elc etc/flycheck-pure.el etc/flycheck-pure.elc $(DESTDIR)$(elispdir)
 endif
 ifneq ($(tmfiles),)
 	for x in $(addprefix $(DESTDIR), $(tmdir)/packages $(tmdir)/plugins/pure/doc $(tmdir)/plugins/pure/progs); do $(INSTALL) -d $$x; done
@@ -420,7 +424,7 @@ ifneq "$(findstring -mingw,$(host))" ""
 	rm -f $(addprefix $(DESTDIR)$(bindir)/, $(libpure) $(libpure_lnkname))
 endif
 ifneq ($(elcfiles),)
-	rm -rf $(addprefix $(DESTDIR), $(elispdir)/pure-mode.el $(elispdir)/pure-mode.elc)
+	rm -rf $(addprefix $(DESTDIR), $(elispdir)/pure-mode.el $(elispdir)/pure-mode.elc $(elispdir)/flycheck-pure.el $(elispdir)/flycheck-pure.elc)
 endif
 ifneq ($(tmfiles),)
 	rm -rf $(addprefix $(DESTDIR), $(addprefix $(tmdir)/,$(patsubst $(srcdir)/texmacs/%,%,$(tmsrc)) plugins/pure))
@@ -442,7 +446,8 @@ olddocs = https://github.com/agraef/pure-lang/releases/download/$(dist)/pure-doc
 install-docs:
 	@MAKE=$(MAKE) ./install-docs.sh "$(docs)" || MAKE=$(MAKE) ./install-docs.sh "$(olddocs)"
 
-# install pure-mode.el and pure-mode.elc
+# install pure-mode.el and pure-mode.elc (as well as flycheck-pure.el and
+# flycheck-pure.elc)
 
 # This will normally be done automatically with 'make install' if emacs is
 # detected on your system. However, these targets also allow you to do this
@@ -450,19 +455,19 @@ install-docs:
 # to install the files in a custom location (in the latter case you will also
 # want to set elispdir accordingly).
 
-install-el: etc/pure-mode.el
+install-el: etc/pure-mode.el etc/flycheck-pure.el
 	$(INSTALL) -d $(DESTDIR)$(elispdir)
-	$(INSTALL) -m 644 $< $(DESTDIR)$(elispdir)
+	$(INSTALL) -m 644 $^ $(DESTDIR)$(elispdir)
 
-install-elc: etc/pure-mode.elc
+install-elc: etc/pure-mode.elc etc/flycheck-pure.elc
 	$(INSTALL) -d $(DESTDIR)$(elispdir)
-	$(INSTALL) -m 644 $< $(DESTDIR)$(elispdir)
+	$(INSTALL) -m 644 $^ $(DESTDIR)$(elispdir)
 
 uninstall-el:
-	rm -rf $(DESTDIR)$(elispdir)/pure-mode.el
+	rm -rf $(DESTDIR)$(elispdir)/pure-mode.el $(DESTDIR)$(elispdir)/flycheck-pure.el
 
 uninstall-elc:
-	rm -rf $(DESTDIR)$(elispdir)/pure-mode.elc
+	rm -rf $(DESTDIR)$(elispdir)/pure-mode.elc $(DESTDIR)$(elispdir)/flycheck-pure.elc
 
 # install the TeXmacs plugin and accompanying files
 

--- a/pure/configure.ac
+++ b/pure/configure.ac
@@ -89,7 +89,7 @@ if test "$pure_cv_gnu_linker" = yes; then
 fi
 
 dnl Install elisp files?
-elcfiles="etc/pure-mode.elc"
+elcfiles="etc/pure-mode.elc etc/flycheck-pure.elc"
 AC_ARG_WITH(elisp,
   [  --with-elisp            install elisp files (default if emacs is available)],
   [case "${withval}" in

--- a/pure/etc/flycheck-pure.el
+++ b/pure/etc/flycheck-pure.el
@@ -1,0 +1,78 @@
+;;; flycheckpure.el --- flycheck checker for Pure
+
+;; Copyright (c) 2018, Albert Graef
+;; All rights reserved.
+
+;; Author: Albert Graef <aggraef@gmail.com>
+;; Keywords: convenience, tools, pure
+;; Version: 0.1.0
+;; URL: https://github.com/agraef/pure-lang
+;; Package-Requires: ((emacs "24") (flycheck "0.22"))
+
+;; This file is not part of GNU Emacs.
+
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions
+;; are met:
+
+;; * Redistributions of source code must retain the above copyright
+;;   notice, this list of conditions and the following disclaimer.
+
+;; * Redistributions in binary form must reproduce the above copyright
+;;   notice, this list of conditions and the following disclaimer in
+;;   the documentation and/or other materials provided with the
+;;   distribution.
+
+;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+;; "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+;; LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+;; FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+;; COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+;; INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+;; (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+;; SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+;; HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+;; STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+;; OF THE POSSIBILITY OF SUCH DAMAGE.
+
+;;; Commentary:
+;; Flycheck checker for Pure (http://www.flycheck.org)
+
+;; To install, copy this file to some directory on your load-path (e.g.,
+;; /usr/share/emacs/site-lisp), make sure that you have flycheck installed and
+;; enable the Pure checker in your .emacs as follows:
+
+;; (require 'flycheck-pure)
+;; (eval-after-load 'flycheck
+;;   '(add-hook 'flycheck-mode-hook #'flycheck-pure-setup))
+
+;;; Code:
+
+(require 'flycheck)
+
+(flycheck-def-option-var flycheck-pure-warnings t pure
+  "Enables warnings (t by default)."
+  :safe #'booleanp
+  :type 'boolean)
+
+(flycheck-define-checker pure
+  "A Pure syntax checker using the Pure interpreter.
+
+See URL `https://agraef.github.io/pure-lang/'."
+  :command ("pure" "--check" (option-flag "-w" flycheck-pure-warnings) source)
+  :error-patterns
+  ((warning line-start (file-name) ", line " line ": warning: " (message) line-end)
+   (error line-start (file-name) ", line " line ": " (message) line-end))
+  :modes pure-mode)
+
+;;;###autoload
+(defun flycheck-pure-setup ()
+  "Flycheck Pure Setup.
+Add `pure' to `flycheck-checkers'."
+  (interactive)
+  (add-to-list 'flycheck-checkers 'pure))
+
+(provide 'flycheck-pure)
+
+;;; flycheck-pure.el ends here

--- a/pure/interpreter.cc
+++ b/pure/interpreter.cc
@@ -1621,7 +1621,7 @@ void interpreter::init_tags()
   if (tagsfile.empty()) {
     if (tags == 2)
       tagsfile = "TAGS";
-    else
+    else if (tags == 1)
       tagsfile = "tags";
     tagsdir = cwd;
   } else {
@@ -1709,7 +1709,7 @@ bool ctag_cmp(const CtagInfo& x, const CtagInfo& y)
 void interpreter::print_tags()
 {
   init_tags();
-  if (chdir(tagsdir.c_str())) perror("chdir");
+  if (tags > 0 && chdir(tagsdir.c_str())) perror("chdir");
   if (tags == 2) {
     ofstream out(tagsfile.c_str());
     for (list<string>::const_iterator it = tag_files.begin(),

--- a/pure/parser.yy
+++ b/pure/parser.yy
@@ -255,7 +255,8 @@ item_pos
 item
 : expr ';'
 { interp.loc = &yyloc;
-  if (!interp.tags) { restricted_action(interp.exec($1), delete $1); }
+  if (interp.tags<0) { restricted_action(interp.parse($1), delete $1); }
+  else if (!interp.tags) { restricted_action(interp.exec($1), delete $1); }
   else delete $1; }
 | ESCAPE expr EOX
 { interp.loc = &yyloc;

--- a/pure/pure.1
+++ b/pure/pure.1
@@ -13,6 +13,9 @@ Batch mode (execute the given scripts and exit).
 .B -c
 Batch compilation (compile the scripts to a native binary).
 .TP
+.B --check
+Syntax check only, do not execute code or produce any output files.
+.TP
 \fB--ctags\fP, \fB--etags\fP
 Create a tags file in ctags (vi) or etags (emacs) format.
 .TP

--- a/pure/pure.cc
+++ b/pure/pure.cc
@@ -102,6 +102,7 @@ using namespace std;
                   pure [options ...] [-b|-c|-i] [script ...] [-- args ...]\n\
 -b                Batch mode (execute given scripts and exit).\n\
 -c                Batch compilation (compile scripts to native binary).\n\
+--check           Syntax check only, do not actually execute scripts.\n\
 --ctags, --etags  Create a tags file in ctags (vi) or etags (emacs) format.\n\
 --disable=optname Disable source option (conditional compilation).\n\
 --eager-jit       Enable eager JIT compilation (LLVM 2.7 or later).\n\
@@ -619,6 +620,10 @@ main(int argc, char *argv[])
 	batch = true; interp.tags = 1;
       } else if (strcmp(arg, "--etags") == 0) {
 	batch = true; interp.tags = 2;
+      } else if (strcmp(arg, "--check") == 0) {
+	// this works basically like tags mode, but only does a syntax check
+	// without generating any other output
+	batch = true; interp.tags = -1;
       } else if (strcmp(arg, "--texmacs") == 0)
 	interp.texmacs = true;
       else if (strcmp(arg, "--eager-jit") == 0)

--- a/pure/pure.txt
+++ b/pure/pure.txt
@@ -241,9 +241,10 @@ of ``-c``, the interpreter then also dumps the program as a native executable,
 performing `batch compilation`, see `Compiling Scripts`_ below.)
 
 Batch mode is also entered if the interpreter is invoked with one of the
-``--ctags`` and ``--etags`` options. However, in this case the given scripts
-are not executed at all, but only parsed in order to produce a vi or emacs
-tags file, see `Tagging Scripts`_ below.
+``--check``, ``--ctags`` and ``--etags`` options. However, in this case the
+given scripts are not executed at all, but only parsed in order to check them
+for syntactic validity, or to produce a vi or emacs tags file, see
+`Tagging Scripts`_ below.
 
 Here are some common ways to invoke the interpreter:
 
@@ -308,6 +309,10 @@ below.
 .. option:: -c
 
    Batch compilation (compile the given scripts to a native binary).
+
+.. option:: --check
+
+   Syntax check only, do not execute code or produce any output files.
 
 .. option:: --ctags
    	    --etags
@@ -459,11 +464,12 @@ Options and source files are processed in the order in which they are given on
 the command line. Processing of options and source files ends when either the
 :option:`--` or the :option:`-x` option is encountered, or after the first
 script (non-option) argument in `script mode` (i.e., if none of the options
-:option:`-b`, :option:`-i`, :option:`--ctags` and :option:`--etags` is
-present). In either case, any remaining parameters are passed to the executing
-script by means of the global :var:`argc` and :var:`argv` variables, denoting
-the number of arguments and the list of the actual parameter strings,
-respectively. In script mode this also includes the script name as ``argv!0``.
+:option:`-b`, :option:`-i`, :option:`--check`, :option:`--ctags` and
+:option:`--etags` is present). In either case, any remaining parameters are
+passed to the executing script by means of the global :var:`argc` and
+:var:`argv` variables, denoting the number of arguments and the list of the
+actual parameter strings, respectively. In script mode this also includes the
+script name as ``argv!0``.
 
 Script mode is useful, in particular, to turn Pure scripts into executable
 programs by including a "shebang" like the following as the first line in your

--- a/pure/pure_norl.cc
+++ b/pure/pure_norl.cc
@@ -66,6 +66,7 @@ using namespace std;
                   pure [options ...] [-b|-c|-i] [script ...] [-- args ...]\n\
 -b                Batch mode (execute given scripts and exit).\n\
 -c                Batch compilation (compile scripts to native binary).\n\
+--check           Syntax check only, do not actually execute scripts.\n\
 --ctags, --etags  Create a tags file in ctags (vi) or etags (emacs) format.\n\
 --disable=optname Disable source option (conditional compilation).\n\
 --eager-jit       Enable eager JIT compilation (LLVM 2.7 or later).\n\
@@ -297,6 +298,10 @@ main(int argc, char *argv[])
 	batch = true; interp.tags = 1;
       } else if (strcmp(arg, "--etags") == 0) {
 	batch = true; interp.tags = 2;
+      } else if (strcmp(arg, "--check") == 0) {
+	// this works basically like tags mode, but only does a syntax check
+	// without generating any other output
+	batch = true; interp.tags = -1;
       } else if (strcmp(arg, "--eager-jit") == 0)
 	interp.eager_jit = true;
       else if (strcmp(arg, "-n") == 0 || strcmp(arg, "--noprelude") == 0)


### PR DESCRIPTION
Adds a new `--check` option which does a dry run without executing any code (syntax check only mode). This is employed to add a flycheck-pure.el module which does syntax checks in Emacs on the fly (requires [flycheck](http://www.flycheck.org)).