### PR TITLE
pure-octave msys2/mingw32 support

### DIFF
--- a/pure-octave/Makefile
+++ b/pure-octave/Makefile
@@ -55,10 +55,22 @@ octave_embed$(DLL): embed.o
 	rm -f $@
 	$(MKOCT_LDCXX) $(shared) $(dllname) -o $@ embed.o $(MKOCT_LDFLAGS) -lpure $(RLD_FLAG)
 else
+ifeq ($(DLL),.dll)
+# Custom build commands for msys2/mingw32 using a static build of Octave 4.0.3.
+# Set this to the staging directory where your build of Octave is installed.
+octave-buildroot = $(HOME)/buildroot-octave/mingw32
+#octave-buildroot = c:/msys64/home/ag/buildroot-octave/mingw32
+octave_embed$(DLL): embed.cc embed.h
+	rm -f $@
+	g++ -c -mieee-fp -g -O2 -I$(octave-buildroot)/include/octave-4.0.3/octave -I$(octave-buildroot)/include/octave-4.0.3 -DOCTAVE_MAJOR=4 -DOCTAVE_MINOR=0 $< -o embed.o
+	g++ -mieee-fp -g -O2 -shared -Wl,--export-all-symbols -Wl,--enable-auto-import -Wl,--enable-runtime-pseudo-reloc  -o $@  embed.o -lpure -L$(octave-buildroot)/lib/octave/4.0.3 -loctinterp -loctave -lglpk -lportaudio -ldsound -lsetupapi -lwinmm -lole32 -luuid -lsndfile -lcurl -lopenblas -lreadline -lncurses -lpcre -lquadmath -lhdf5 -lfftw3 -lfftw3f -lfontconfig -lfreetype -lopengl32 -lglu32 -lgdi32 -lws2_32 -lgfortran -lz
+	strip $@
+else
 octave_embed$(DLL): embed.cc embed.h
 	rm -f $@
 	$(mkoctfile) -v $(octversionflag) -o $@ $< -lpure $(RLD_FLAG)
 	if test -f $@.oct; then mv $@.oct $@; fi
+endif
 endif
 
 clean:

--- a/pure-octave/gnuplot.pure
+++ b/pure-octave/gnuplot.pure
@@ -239,6 +239,9 @@ mouse_wheel_zoom args = octave_call "mouse_wheel_zoom" 0 args;
 // Some Octave installations default to the 'fltk' graphics toolkit which
 // doesn't work very well in Pure (no interactivity). Use 'gnuplot' as a
 // portable default instead, this seems to work fine on both Linux and OSX.
+// NB: On some platforms, gnuplot is not automatically registered even though
+// it's supported, so we do that first to be on the safe side.
+octave_eval "register_graphics_toolkit('gnuplot');";
 octave_eval "graphics_toolkit('gnuplot');";
 
 /* The following aren't plotting functions, but they are useful in many plot

--- a/pure-octave/octave.pure
+++ b/pure-octave/octave.pure
@@ -21,6 +21,77 @@ using "lib:octave_embed";
 extern void octave_init(int argc, char **argv);
 extern void octave_fini();
 
+#! --if *-mingw32
+// Windows kludge: Make sure that octave finds its m files.
+extern void _putenv(char*);
+() when
+  // Adjust these as needed. Note the backslashes. Slashes do NOT work here.
+  // In a self-contained installation, we have these in the Pure libdir:
+  pref = "\\msys64\\mingw32\\lib\\pure\\octave\\";
+  // This is the install prefix for a standard msys2/mingw32 install of
+  // Octave, use this instead if you installed Octave yourself:
+  //pref = "\\msys64\\mingw32\\share\\octave\\";
+  // Default path gleaned from a Linux install of Octave 4.0.3. You may have
+  // to adjust this if you're running your own Octave installation and you'd
+  // rather want to pull the m files and oct modules from there.
+  path = join ";" $ map (pref+)
+    ["site\\m",
+     "site\\m\\startup",
+     "4.0.3\\m",
+     "4.0.3\\m\\audio",
+     "4.0.3\\m\\deprecated",
+     "4.0.3\\m\\elfun",
+     "4.0.3\\m\\general",
+     "4.0.3\\m\\geometry",
+     "4.0.3\\m\\gui",
+     "4.0.3\\m\\help",
+     "4.0.3\\m\\image",
+     "4.0.3\\m\\io",
+     "4.0.3\\m\\java",
+     "4.0.3\\m\\linear-algebra",
+     "4.0.3\\m\\miscellaneous",
+     "4.0.3\\m\\ode",
+     "4.0.3\\m\\optimization",
+     "4.0.3\\m\\path",
+     "4.0.3\\m\\pkg",
+     "4.0.3\\m\\plot",
+     "4.0.3\\m\\plot\\appearance",
+     "4.0.3\\m\\plot\\draw",
+     "4.0.3\\m\\plot\\util",
+     "4.0.3\\m\\polynomial",
+     "4.0.3\\m\\prefs",
+     "4.0.3\\m\\profiler",
+     "4.0.3\\m\\set",
+     "4.0.3\\m\\signal",
+     "4.0.3\\m\\sparse",
+     "4.0.3\\m\\specfun",
+     "4.0.3\\m\\special-matrix",
+     "4.0.3\\m\\startup",
+     "4.0.3\\m\\statistics",
+     "4.0.3\\m\\statistics\\base",
+     "4.0.3\\m\\statistics\\distributions",
+     "4.0.3\\m\\statistics\\models",
+     "4.0.3\\m\\statistics\\tests",
+     "4.0.3\\m\\strings",
+     "4.0.3\\m\\testfun",
+     "4.0.3\\m\\time",
+     "4.0.3\\data"];
+  path = ".;"+path;
+  // Note that we only set a minimal environment here so that the embedded
+  // Octave finds its m files and the stuff necessary to make the help command
+  // work (sort of; you'll still need makeinfo and info programs which work in
+  // the DOS command line, or be content with the plain text rendering). By
+  // redefining pref above we can just relocate all these files as needed.
+  _putenv("OCTAVE_PATH="+path);
+  _putenv("OCTAVE_BUILT_IN_DOCSTRINGS_FILE=" + pref +
+	  "4.0.3\\etc\\built-in-docstrings");
+  _putenv("OCTAVE_DOC_CACHE_FILE=" + pref +
+	  "4.0.3\\etc\\doc-cache");
+  _putenv("OCTAVE_TEXI_MACROS_FILE=" + pref +
+	  "4.0.3\\etc\\macros.texi");
+end;
+#! --endif
+
 // Initialize Octave. The command line options are for quiet startup (no
 // sign-on message) and to disable Octave's command history (to prevent Octave
 // from clobbering Pure's readline).


### PR DESCRIPTION
Various kludges to make this module work on Windows in the msys2/mingw32 environment.