### PR TITLE
Batch compiler fixes

### DIFF
--- a/gnumeric-pure/pure-gnm/pure-gnm.pure
+++ b/gnumeric-pure/pure-gnm/pure-gnm.pure
@@ -87,8 +87,4 @@ end) with
 end;
 usage = fputs "Usage: pure-gnm script\n" stderr $$ exit 1;
 
-#! --if compiled
-if compiling then () else if argc==2 then main (argv!1) else usage;
-#! --else
 if argc < 1 then () else if argc==2 then main (argv!1) else usage;
-#! --endif

--- a/pure-avahi/zeroconf.pure
+++ b/pure-avahi/zeroconf.pure
@@ -27,12 +27,12 @@
 namespace zeroconf;
 
 #! --if avahi
-eval "using \"lib:avahi\";" === () &&
+let eval "using \"lib:avahi\";" === () &&
 (eval "#! --enable avahi\n#! --disable bonjour\n"$$true) ||
 eval "#! --disable avahi\n";
 #! --endif
 #! --if bonjour
-eval "using \"lib:bonjour\";" === () &&
+let eval "using \"lib:bonjour\";" === () &&
 (eval "#! --enable bonjour\n#! --disable avahi\n"$$true) ||
 eval "#! --disable bonjour\n";
 #! --endif

--- a/pure-bonjour/zeroconf.pure
+++ b/pure-bonjour/zeroconf.pure
@@ -27,12 +27,12 @@
 namespace zeroconf;
 
 #! --if avahi
-eval "using \"lib:avahi\";" === () &&
+let eval "using \"lib:avahi\";" === () &&
 (eval "#! --enable avahi\n#! --disable bonjour\n"$$true) ||
 eval "#! --disable avahi\n";
 #! --endif
 #! --if bonjour
-eval "using \"lib:bonjour\";" === () &&
+let eval "using \"lib:bonjour\";" === () &&
 (eval "#! --enable bonjour\n#! --disable avahi\n"$$true) ||
 eval "#! --disable bonjour\n";
 #! --endif

--- a/pure-fastcgi/examples/primes.pure
+++ b/pure-fastcgi/examples/primes.pure
@@ -51,4 +51,4 @@ when
   self = "http://"+server+script;
 end;
 
-if compiling then () else main 0 [];
+main 0 [];

--- a/pure-fastcgi/examples/request.pure
+++ b/pure-fastcgi/examples/request.pure
@@ -100,4 +100,4 @@ end;
 /* Invoke the 'main' function. This has been set up so that you can also
    compile the script to a native executable. */
 
-if compiling then () else main;
+main;

--- a/pure-fastcgi/examples/tinyfastcgi.pure
+++ b/pure-fastcgi/examples/tinyfastcgi.pure
@@ -23,4 +23,4 @@ Request number %d running on host <i>%s</i>\n"
   (count,check (getenv "SERVER_NAME"));
 end if accept >= 0;
 
-if compiling then () else main 0;
+main 0;

--- a/pure-ffi/ffi.pure
+++ b/pure-ffi/ffi.pure
@@ -40,7 +40,8 @@ extern expr *ffi_put_struct_member(expr *x, int i, expr *y);
    type_info function, see below. Use 'show -g FFI_*' to get a full list of
    these constants. */
 
-extern void ffi_defs(); ffi_defs;
+extern void ffi_defs();
+let ffi_defs;
 
 namespace;
 

--- a/pure-g2/g2_life.pure
+++ b/pure-g2/g2_life.pure
@@ -131,4 +131,4 @@ end;
 /****************************************************************************/
 
 // Sample main program:
-if compiling then () else life (100,100) glider_gun;
+life (100,100) glider_gun;

--- a/pure-g2/g2_test.pure
+++ b/pure-g2/g2_test.pure
@@ -154,4 +154,4 @@ test = () when
   g2_close d;
 end;
 
-if compiling then () else test;
+test;

--- a/pure-gtk/examples/hello.pure
+++ b/pure-gtk/examples/hello.pure
@@ -62,4 +62,4 @@ when
   gtk::widget_show window;
 end;
 
-if compiling then () else main;
+main;

--- a/pure-gtk/examples/life.pure
+++ b/pure-gtk/examples/life.pure
@@ -209,4 +209,4 @@ end;
 /****************************************************************************/
 
 // Sample main program:
-if compiling then () else life (100,100) glider_gun;
+life (100,100) glider_gun;

--- a/pure-gtk/examples/uiexample.pure
+++ b/pure-gtk/examples/uiexample.pure
@@ -111,4 +111,4 @@ when
   gtk::widget_show (GTK_WIDGET window);
 end;
 
-if compiling then () else main;
+main;

--- a/pure-liblo/examples/osc_example.pure
+++ b/pure-liblo/examples/osc_example.pure
@@ -10,7 +10,7 @@ using namespace lo;
 let s = osc_server 7770;
 let t = make_address 7770;
 
-if null s then exit 1 else if compiling then () else
+if null s then exit 1 else
 printf "OSC server running at %s\n" (server_thread_get_url s);
 
 // Output a few messages (cf. client.pure).
@@ -48,7 +48,7 @@ osc_send_timestamped t (timetag NULL 5) "/quit" "" ();
 
 // Now read them back:
 
-if compiling then () else puts "Reading messages:" $$
+puts "Reading messages:" $$
 osc_main ["*"=>generic,"/foo/bla"=>foo,"/quit"=>quit] with
   generic addr ts path types data =
     printf "generic [%08x.%08x]: %s, types: %s, args: %s\n"

--- a/pure-liblo/examples/server.pure
+++ b/pure-liblo/examples/server.pure
@@ -78,6 +78,5 @@ server_add_method s "/quit" "" quit_cb NULL;
    point it invokes the appropriate callback, if any. We might also use
    lo::server_recv_noblock here if we want to do some idle time processing. */
 
-if compiling then () else
 printf "OSC server running at %s\n" (server_get_url s) $$
 loop with loop = server_recv s $$ loop end;

--- a/pure-lilv/examples/synth.pure
+++ b/pure-lilv/examples/synth.pure
@@ -53,15 +53,15 @@ end;
 
 let have_synth, have_midi = false, true;
 
-#! --if compiled
+#! --ifnot interactive
 // Parse the command line. Check whether we got a synth in argv!1.
 let have_synth = argc>=2 && any (==argv!1) synths;
 // Check whether we got a MIDI file as well.
 let have_midi = argc~=2 || ~have_synth;
 // In the compiled script, allow the user to pick a synth (and, optionally, a
 // preset) from the command line.
-let synth_name = if compiling || ~have_synth then synth_name else argv!1;
-let preset_name = if compiling || ~have_synth || argc<=3 then "" else argv!2;
+let synth_name = if ~have_synth then synth_name else argv!1;
+let preset_name = if ~have_synth || argc<=3 then "" else argv!2;
 // Print a short usage message and the list of available synth units if we're
 // invoked without arguments.
 let USAGE = "Usage: %s [synth-name [preset-name]] midifile\n\
@@ -69,7 +69,7 @@ Or use %s synth-name to get a list of all presets for the given synth.\n\
 E.g., if you have the Calf Organ installed, try something like:\n\
 %s 'Calf Organ' Shamrock prelude3.mid\n\
 \nAvailable synth units:\n%s\n";
-compiling || argc>=2 ||
+argc>=2 ||
 (fprintf stderr USAGE (prog,prog,prog,join ", " synths) $$ exit 1 when
    prog = head argv;
  end);
@@ -84,8 +84,9 @@ using namespace audio;
 let devs = devices;
 let outdev = output;
 
-// Sample rate.
-let SR = devs!outdev!4;
+// Sample rate. (The device list may be empty, provide a reasonable default in
+// that case.)
+let SR = catch (cst 44100) (devs!outdev!4);
 
 /* Some magic numbers, the block size for running the synth, and the buffer
    size for the audio playback. The latter (size) must be a multiple (m) of
@@ -190,16 +191,16 @@ let presets = record {name=>uri | name,uri = lilv::presets world synth};
 ~stringp preset_name || null preset_name || ~member presets preset_name ||
 lilv::load_preset world (presets!preset_name) synth;
 
-#! --if compiled
+#! --ifnot interactive
 // Print the name of the synth that was chosen and the preset.
-compiling || printf "Synth: %s\n" synth_name;
+printf "Synth: %s\n" synth_name;
 let have_preset = stringp preset_name && ~null preset_name;
-compiling || ~have_preset || printf "Preset: %s\n" preset_name;
+~have_preset || printf "Preset: %s\n" preset_name;
 // If no MIDI file or preset was given, print the available presets.
-compiling || have_preset || have_midi || null presets ||
+have_preset || have_midi || null presets ||
 printf "Available presets:\n%s\n" (join ", " (list (keys presets)));
 // If we were invoked with just the synth name, bail out now.
-compiling || have_midi || exit 1;
+have_midi || exit 1;
 #! --endif
 
 // Create buffers.
@@ -258,8 +259,8 @@ end;
 
 // Main program, lets you specify a midi file on the command line.
 
-#! --if compiled
+#! --ifnot interactive
 main = play seq if listp seq when seq = load (last argv) end;
 = fprintf stderr "bad MIDI file: %s\n" (last argv) $$ exit 1 otherwise;
-compiling || catch (\_->exit 1) main;
+catch (\_->exit 1) main;
 #! --endif

--- a/pure-octave/examples/plot_demo.pure
+++ b/pure-octave/examples/plot_demo.pure
@@ -35,7 +35,7 @@ using namespace gnuplot;
 #! --if compiled
 using system;
 const delta = 3; // seconds to pause between plots
-pause = if compiling then popdn() else refresh() $$ sleep delta;
+pause = refresh() $$ sleep delta;
 #! --else
 pause = refresh();
 #! --endif
@@ -117,7 +117,7 @@ let t = 0:0.2..20;
 let s = [sin(t)*exp(-t/5) | t = t];
 let a = [0, 20, -1, 1];
 let n = 8;
-compiling || do frame $ linspace(0,n*pi,200) with
+do frame $ linspace(0,n*pi,200) with
   frame k = () when
     plot(t, map (sin(k)*) s);
     axis(a);

--- a/pure-octave/octave.pure
+++ b/pure-octave/octave.pure
@@ -24,7 +24,7 @@ extern void octave_fini();
 #! --if *-mingw32
 // Windows kludge: Make sure that octave finds its m files.
 extern void _putenv(char*);
-() when
+let () when
   // Adjust these as needed. Note the backslashes. Slashes do NOT work here.
   // In a self-contained installation, we have these in the Pure libdir:
   pref = "\\msys64\\mingw32\\lib\\pure\\octave\\";
@@ -95,7 +95,7 @@ end;
 // Initialize Octave. The command line options are for quiet startup (no
 // sign-on message) and to disable Octave's command history (to prevent Octave
 // from clobbering Pure's readline).
-octave_init 3 (byte_string_pointer ["octave","-q","-H"]);
+let octave_init 3 (byte_string_pointer ["octave","-q","-H"]);
 
 // Execute an Octave command.
 extern int octave_eval(char *cmd);

--- a/pure-sockets/examples/dgram.pure
+++ b/pure-sockets/examples/dgram.pure
@@ -154,5 +154,5 @@ catch error main with
     [_,"client"] = client 5002;
     [_,"client",port] = client port if intp port when port = val port end;
     _ = fprintf stderr "Usage: %s server | %s client [port]\n" (argv!0,argv!0);
-  end if ~compiling && argc>0;
+  end if argc>0;
 end;

--- a/pure-sockets/examples/stream.pure
+++ b/pure-sockets/examples/stream.pure
@@ -90,5 +90,5 @@ catch error main with
     [_,"server"] = server;
     [_,"client"] = client;
     _ = fprintf stderr "Usage: %s server|client\n" (argv!0);
-  end if ~compiling && argc>0;
+  end if argc>0;
 end;

--- a/pure-sockets/sockets.pure
+++ b/pure-sockets/sockets.pure
@@ -34,7 +34,7 @@ extern int sockaddr_port(sockaddr*);
 extern char* sockaddr_service(sockaddr*);
 
 // Define some manifest constants.
-__socket_defs;
+let __socket_defs;
 
 /* Socket functions from the C library. */
 

--- a/pure-stldict/examples/life.pure
+++ b/pure-stldict/examples/life.pure
@@ -127,7 +127,7 @@ let opts = ["--number","--width","--height","--xcoord","--ycoord","--time"];
 let full_opts = [s,s!![1,2],REQARG | s = opts];
 let defaults = zipwith (=>) opts [n,w,h,x,y,t];
 
-compiling || argc<=1 || main with
+argc<=1 || main with
   main = catch usage $ (life.tuple.args) argv;
   args v = case getopt full_opts v of
     a,[_,b] = map eval (b : list (record (defaults+a)!!opts));

--- a/pure-stllib/pure-stlmap/dev/setup_wk_source.pure
+++ b/pure-stllib/pure-stlmap/dev/setup_wk_source.pure
@@ -79,7 +79,7 @@ main = () when
     puts usage;   
 end;
 
-if compiling || argc == 0 then () else main;
+if argc == 0 then () else main;
 
 x_main nws nks= make_words_keys_aux 7 nws nks sf wf kf;
 

--- a/pure-stllib/pure-stlmap/dev/timer_template.pure
+++ b/pure-stllib/pure-stlmap/dev/timer_template.pure
@@ -285,4 +285,4 @@ main = () when
     puts usage;   
 end;
 
-if compiling || argc == 0 then () else main;
+if argc == 0 then () else main;

--- a/pure-stllib/pure-stlvec/examples/collatz.pure
+++ b/pure-stllib/pure-stlvec/examples/collatz.pure
@@ -37,4 +37,4 @@ end;
 main = if argc ~= 2 then puts "usage: collatz n"
        else puts $ str (maxchain 1 (atoi (argv!1)));
 
-if compiling then () else main;
+main;

--- a/pure-stllib/pure-stlvec/examples/grader.pure
+++ b/pure-stllib/pure-stlvec/examples/grader.pure
@@ -451,7 +451,7 @@ main args = () when
   fclose out;
 end;
 
-if ~compiling && argc > 0 then main (tail argv) else ();
+if argc > 0 then main (tail argv) else ();
 
 let test_args = ["grader_config.txt", "-rr", "-f", "grader_data.txt"];
 

--- a/pure-stllib/pure-stlvec/examples/sieve.pure
+++ b/pure-stllib/pure-stlvec/examples/sieve.pure
@@ -68,7 +68,7 @@ main = if argc < 3 then
 	 _ = puts "bad number";
        end;
 
-if ~compiling && argc > 0 then main else ();
+if argc > 0 then main else ();
 
 /*** Times on an old Dell running Linux Mint ********************************
 

--- a/pure-stllib/pure-stlvec/ut/ut_all.pure
+++ b/pure-stllib/pure-stlvec/ut/ut_all.pure
@@ -41,4 +41,4 @@ test_all = ok when
   else puts "\n--- PASSED STLVEC UNIT TESTS ---" $$ exit 0;
 end;
 
-if ~compiling then test_all else ();
+test_all;

--- a/pure-tk-examples/graphedit/graphedit.pure
+++ b/pure-tk-examples/graphedit/graphedit.pure
@@ -991,4 +991,5 @@ main fname = () when
   gnocl::main ();
 end;
 
-if compiling then pragmas else main (if argc>1 then argv!1 else ());
+const pragmas;
+main (if argc>1 then argv!1 else ());

--- a/pure-tk-examples/pong/pong.pure
+++ b/pure-tk-examples/pong/pong.pure
@@ -308,4 +308,5 @@ main = () when
   gnocl::main ();
 end;
 
-if compiling then pragmas else main;
+const pragmas;
+main;

--- a/pure-tk-examples/scale/scale.pure
+++ b/pure-tk-examples/scale/scale.pure
@@ -910,4 +910,4 @@ main = () when
   tk_main;
 end;
 
-if compiling then () else main;
+main;

--- a/pure-tk/examples/earth.pure
+++ b/pure-tk/examples/earth.pure
@@ -56,4 +56,4 @@ main = tk earth $$ tk_main when
   argc < 2 || tk (sprintf "set GTK %d" (argv!1 ~= "-tk"));
 end;
 
-if compiling then () else main;
+main;

--- a/pure-tk/examples/tk_examp.pure
+++ b/pure-tk/examples/tk_examp.pure
@@ -72,4 +72,4 @@ quit_cb = tk_quit;
 /* The main program. This is set up so that you can compile this script
    to a native executable as follows: pure -c tk_examp.pure -o tk_examp. */
 
-if compiling then () else main;
+main;

--- a/pure-tk/examples/tk_hello.pure
+++ b/pure-tk/examples/tk_hello.pure
@@ -15,4 +15,4 @@ main text = tk (sprintf "button .b -text %s -command {puts %s}; pack .b"
    to a native executable as follows: pure -c tk_hello.pure -o tk_hello. */
 
 let text = if argc>1 then argv!1 else "Hello, world!";
-if compiling then () else main text;
+main text;

--- a/pure-tk/examples/uiexample.pure
+++ b/pure-tk/examples/uiexample.pure
@@ -68,4 +68,4 @@ main = () when
   gnocl::main (w!"window1");
 end;
 
-if compiling then () else main;
+main;

--- a/pure/ChangeLog
+++ b/pure/ChangeLog
@@ -1,3 +1,13 @@
+2018-04-10  Albert Graef  <aggraef@gmail.com>
+
+	* interpreter.cc et al: The batch compiler now doesn't execute
+	plain toplevel expressions at compile time any more, which makes
+	writing batch-compiled scripts much more straightforward. The
+	'compiling' variable is still supported for backward
+	compatibility, so most existing scripts should continue to work
+	unchanged, but the compiler flags it as "deprecated" now if
+	warnings are enabled (-w).
+
 2018-03-18  Albert Graef  <aggraef@gmail.com>
 
 	* 0.67 release: a bunch of smaller bugfixes and updates, updated

--- a/pure/examples/life.pure
+++ b/pure/examples/life.pure
@@ -67,4 +67,4 @@ print (n,m) b = puts $ join "\n"
 life (n,m) b = do (print (n,m)) $ iterate (next (n,m)) b;
 
 // Example:
-if compiling then () else life (50,50) glider_gun;
+life (50,50) glider_gun;

--- a/pure/examples/recursive.pure
+++ b/pure/examples/recursive.pure
@@ -51,4 +51,4 @@ main _ = usage otherwise;
 usage = puts "Usage: time pure recursive.pure N";
 
 extern int atoi(char*);
-if compiling then () else if argc~=2 then usage else main $ atoi $ argv!1;
+if argc~=2 then usage else main $ atoi $ argv!1;

--- a/pure/interpreter.hh
+++ b/pure/interpreter.hh
@@ -815,8 +815,9 @@ public:
      anything. It is still checked that the variable symbol is not already
      bound to a different kind of symbol, otherwise an err exception is
      thrown. */
-  void defn(int32_t tag, pure_expr *x);
-  void defn(const char *varname, pure_expr *x);
+  void defn(int32_t tag, pure_expr *x, bool deprecated = false);
+  void defn(const char *varname, pure_expr *x, bool deprecated = false);
+  set<int32_t> deprecated_vars;
 
   /* Constant definitions. These work like the variable definition methods
      above, but define constant symbols which are directly substituted into

--- a/pure/lib/enum.pure
+++ b/pure/lib/enum.pure
@@ -17,6 +17,19 @@
 
      using enum;
 
+   Also note that the :func:`enum` and :func:`defenum` functions use
+   meta-programming to modify the running program, which only works when
+   running in the interpreter. Thus, if a script using these functions is to
+   be compiled to a native executable, you need to make sure that calls to
+   :func:`enum` and :func:`defenum` are invoked at compile time. The ``const``
+   keyword does this for you, e.g.::
+
+     const enum day;
+
+   This isn't necessary if the script runs in the interpreter, but it won't
+   hurt there either, so to be on the safe side, it is recommended to just
+   always use ``const`` with these operations.
+
    The following operations are provided:
 
    .. function:: enum sym
@@ -60,12 +73,12 @@
    Once the type is defined, we can turn it into an enumeration simply as
    follows::
 
-     enum day;
+     const enum day;
 
    There's also a convenience function :func:`defenum` which defines the type
    and makes it enumerable in one go::
 
-     defenum day [sun,mon,tue,wed,thu,fri,sat];
+     const defenum day [sun,mon,tue,wed,thu,fri,sat];
 
    In particular, this sets up the functions ``day`` and ``ord`` so that you
    can convert between members of the ``day`` type and the corresponding
@@ -132,14 +145,6 @@
 
 public enum enump enumof defenum;
 
-/* We only want enum to be executed when running interpreted, since it
-   requires meta programming stuff that's not available in native executables.
-   So for batch-compiled scripts you need to make sure that enum gets invoked
-   at compile time. */
-
-#! --if compiled
-enum name::symbol = () if ~compiling;
-#! --endif
 enum name::symbol = () when
   defs = zip defs (0..#defs-1);
   add_fundef $ ['(ord x-->n) | (_ x-->v),n = defs; ok x v] +
@@ -151,9 +156,6 @@ end if ~null defs && all symbolp [x | _ x-->_ = defs] when
   defs = get_typedef name;
 end;
 
-#! --if compiled
-defenum name::symbol elts::list = () if ~compiling;
-#! --endif
 defenum name::symbol elts::list = enum name when
   // Make sure that all the symbols are nonfix.
   eval $ "nonfix "+join " " (map str elts);

--- a/pure/lib/regex.pure
+++ b/pure/lib/regex.pure
@@ -52,7 +52,8 @@ using namespace __C;
 namespace __C;
 // Initialize some global variables needed for the regex functions. After
 // loading this module, see show -gcv * for a list of these.
-extern void pure_regex_vars(); pure_regex_vars;
+extern void pure_regex_vars();
+let pure_regex_vars;
 // Lowlevel interface to the POSIX regex functions provided in the runtime.
 extern void* pure_regcomp(char* pat, int cflags) = regcomp;
 extern int pure_regexec(void* reg, char* s, int eflags) = regexec;

--- a/pure/lib/system.pure
+++ b/pure/lib/system.pure
@@ -54,7 +54,9 @@
    these. */
 
 namespace __C;
-extern void pure_sys_vars(); pure_sys_vars;
+extern void pure_sys_vars();
+// Make sure that these variables are also defined in batch compilation.
+let pure_sys_vars;
 namespace;
 
 /* ..

--- a/pure/pure.txt
+++ b/pure/pure.txt
@@ -340,7 +340,9 @@ below.
 .. option:: -fPIC
    	    -fpic
 
-   Create position-independent code (batch compilation).
+   Create position-independent code (batch compilation). (This option will
+   normally be added automatically on platforms where it is needed, so you'll
+   rarely have to specify this explicitly.)
 
 .. option:: -g
 
@@ -491,7 +493,10 @@ The following variables are always predefined by the interpreter:
 .. variable:: compiling
 
    A flag indicating whether the program is executed in a batch compilation
-   (:option:`-c` option), see `Compiling Scripts`_ below.
+   (:option:`-c` option), see `Compiling Scripts`_ below. (This variable is
+   still provided for backward compatibility, but shouldn't be needed any more
+   and is considered deprecated. The compiler will warn about its use when the
+   :option:`-w <pure -w>` option is specified.)
 
 .. variable:: version
    	      sysinfo
@@ -543,17 +548,17 @@ otherwise this option will be ignored.
 It is also possible to compile your scripts to native code beforehand, using
 the :option:`-c` batch compilation option. This option forces the interpreter
 to batch mode (unless :option:`-i` is specified as well, which overrides
-:option:`-c`). Any scripts specified on the command line are then executed as
-usual, but after execution the interpreter takes a snapshot of the program and
-compiles it to one of several supported output formats, LLVM assembler (.ll)
-or bitcode (.bc), native assembler (.s) or object (.o), or a native
-executable, depending on the output filename specified with :option:`-o`. If
-the output filename ends in the .ll extension, an LLVM assembler file is
-created which can then be processed with the LLVM toolchain. If the output
-filename is just '-', the assembler file is written to standard output, which
-is useful if you want to pass the generated code to the LLVM tools in a
-pipeline. If the output filename ends in the .bc extension, an LLVM bitcode
-file is created instead.
+:option:`-c`). Any scripts specified on the command line are then compiled as
+usual (only bypassing immediate execution of toplevel expressions) and the
+interpreter finally takes a snapshot of the program and outputs it in one of
+several supported output formats, LLVM assembler (.ll) or bitcode (.bc),
+native assembler (.s) or object (.o), or a native executable, depending on the
+output filename specified with :option:`-o`. If the output filename ends in
+the .ll extension, an LLVM assembler file is created which can then be
+processed with the LLVM toolchain. If the output filename is just '-', the
+assembler file is written to standard output, which is useful if you want to
+pass the generated code to the LLVM tools in a pipeline. If the output
+filename ends in the .bc extension, an LLVM bitcode file is created instead.
 
 The .ll and .bc formats are supported natively by the Pure interpreter, no
 external tools are required to generate these. If the target is an .s, .o or
@@ -3078,6 +3083,8 @@ if the discriminant ``d = p^2/4-q`` is nonnegative::
 Note that the above definition leaves the case of a negative discriminant
 undefined.
 
+.. _Simple Rules:
+
 Simple Rules
 ------------
 
@@ -3566,45 +3573,14 @@ instance:
 .. code-block:: console
 
    $ pure -c hello.pure -o hello
-   Hello, world!
    $ ./hello
    Hello, world!
 
-You'll notice that the compilation command in the first line above *also*
-prints the ``Hello, world!`` message. This reveals a rather unusual aspect of
-Pure's batch compiler: it actually *executes* the script even during batch
-compilation. The reasons for this behaviour and potential uses are discussed
-in the `Batch Compilation`_ section. If you want to suppress the program
-output during batch compilation, you can rewrite the program as follows::
-
-  using system;
-  main = puts "Hello, world!";
-  compiling || main;
-
-Note that here we turned the code to be executed into a separate ``main``
-function. This isn't really necessary, but often convenient, since it allows
-us to run the code to be executed by just evaluating a single function. (Note
-that in contrast to C, the name ``main`` has no special significance in Pure;
-it's just a function like any other. We still have to include a call to this
-function at the end of our program so that it gets executed.)
-
-The last line now reads ``compiling || main`` which is a shorthand for "if the
-``compiling`` variable is nonzero then do nothing, otherwise evaluate the
-``main`` function". In a batch compilation the interpreter sets this variable
-to a nonzero value so that the evaluation of ``main`` is skipped:
-
-.. code-block:: console
-
-   $ pure -c hello.pure -o hello
-   $ ./hello
-   Hello, world!
-
-We should mention here that batch-compiled scripts have some limitations
-because the compiled executable runs under a trimmed-down runtime system. This
-disables some of the advanced compile time features which are only available
-when running a script with the interpreter or at batch-compilation time.
-However, this won't usually affect run-of-the-mill scripts like the one above.
-More information about this can be found in the `Batch Compilation`_ section.
+We should mention here that batch-compiled scripts have some limitations. In
+particular, some of the advanced compile time features are only available when
+running a script with the interpreter. However, this won't affect
+run-of-the-mill scripts like the one above. More information can be found in
+the `Batch Compilation`_ section.
 
 Running the Interpreter
 -----------------------
@@ -12241,64 +12217,74 @@ skip these initializations.
 Batch Compilation
 =================
 
-The interpreter's :option:`-c` option provides a means to turn Pure scripts
-into standalone executables. This feature is still a bit experimental. In
-particular, note that the compiled executable is essentially a *static
-snapshot* of your program which is executed on the "bare metal", without a
-hosting interpreter. Only a minimal runtime system is provided. This
-considerably reduces startup times, but also implies some quirks and
-limitations as detailed below.
+The interpreter's :option:`-c` option provides a means to quickly turn Pure
+scripts into standalone executables. The compiled executable is essentially a
+*static snapshot* of your program which is executed on the "bare metal",
+without a hosting interpreter and with just a minimal runtime system. This
+considerably reduces startup times, but also implies some limitations (mostly
+related to meta-programming capabilities) which will be discussed in the
+following subsection, where we give a detailed account on the batch
+compilation process.
 
-First and foremost, the batch compiler always reorders the code so that all
-toplevel expressions and :keyword:`let` bindings are evaluated *after* all
-functions have been defined. This is done to reduce the size of the output
-executable, so that there's only a *single* snapshot of each function which
-will be used by all toplevel expressions and global variable definitions
-invoking the function. Therefore you should avoid code like the following::
+Compile Time Versus Run Time
+----------------------------
+
+The batch compiler processes most of the script at compile time as usual. The
+only exception are plain toplevel expressions which are *not* executed during
+batch compilation, but of course they are compiled and become part of the
+output code. Your program will normally have to include at least one of these
+so that it does something useful. That is, the toplevel expressions play the
+role of the "main program" in your script. They are best placed after all the
+function and variable definitions, at the end of your program.
+
+All other items (macro, type, function, constant and variable definitions) are
+executed *at compile time* as usual. This might first seem a bit weird, but it
+paves the way for the powerful programming technique of `partial evaluation`_
+(more about that later). In any case, compile-time execution can't really be
+avoided in a highly dynamic language like Pure. Recall that even constants can
+be defined by evaluating arbitrary expressions, and using :func:`eval` a
+program can easily modify itself in even more unforeseeable ways.
+
+.. _partial evaluation: http://en.wikipedia.org/wiki/Partial_evaluation
+
+Thus it is important to keep in mind that if :keyword:`const` and
+:keyword:`let` bindings involve any code to be executed, that code will be run
+also during batch compilation. What this means is that permanent side-effects
+such as creating or removing files should be avoided in these definitions;
+stuff like reading files in order to initialize constants and variables should
+be ok, though. Other side-effects should be confined to the toplevel
+expressions making up your main program. (The compiler has no way of checking
+these policies, so they are the programmer's responsibility.)
+
+In the case of :keyword:`const`, the code needed to construct these values
+will normally be run *only* during batch compilation and the resulting values
+are then either inlined in other definitions or stored as read-only variables,
+see `Constant Definitions`_ for details. In contrast, the code for
+:keyword:`let`-bound variables will actually be executed *twice*, once during
+batch compilation, and then again when the compiled program runs.
+
+.. note:: There's one corner case in which :keyword:`const` is treated pretty
+   much the same as :keyword:`let`, namely if a constant involves run time
+   data such as pointers and closures. In such cases the constant value has to
+   be recomputed at run time and effectively becomes a (read-only) variable.
+   (The same applies if the :option:`--noconst` option is used to force
+   computation of constant values at run time, see `Options Affecting Code
+   Size`_.)
+
+The batch compiler always reorders the output code so that all toplevel
+expressions and :keyword:`let` bindings are evaluated *after* all functions
+have been defined. This is done to reduce the size of the output executable,
+so that there's only a *single* snapshot of each function which will be used
+by all toplevel expressions and global variable definitions invoking the
+function. Therefore you should avoid code like the following, which changes
+the function ``foo`` on the fly between invocations::
 
   let x = foo 99;
   foo x = x+1;
   let y = foo 99;
 
-Note that if you run this through the interpreter, ``x`` and ``y`` are bound
-to ``foo 99`` and ``100``, respectively, because expressions and variable
-definitions are executed immediately, as the program is being processed. In
-contrast, if the same program is batch-compiled, *both* variables will be
-defined *after* the definition of ``foo`` and thus refer to the same value
-``100`` instead. This will rarely be a problem in practice (the above example
-is really rather pathological and won't usually occur in real-world programs),
-but to avoid these semantic differences, you'll have to make sure that
-expressions are evaluated *after* all functions used in the evaluation have
-been defined completely. (However, the batch compiler currently doesn't check
-this condition and will happily generate code for programs which violate it.)
-
-Plain toplevel expressions won't be of much use in a batch-compiled program,
-unless, of course, they are evaluated for their side-effects. Your program
-will have to include at least one of these to play the role of the "main
-program" in your script. In most cases these expressions are best placed after
-all the function and variable definitions, at the end of your program.
-
-Also note that during a batch compilation, the compiled program is actually
-executed as usual, i.e., the script is also run *at compile time*. This might
-first seem to be a big annoyance, but it actually opens the door for some
-powerful programming techniques like `partial evaluation`_. It is also a
-necessity because of Pure's highly dynamic nature. For instance, Pure allows
-you to define constants by evaluating an arbitrary expression (cf. `Constant
-Definitions`_), and using :func:`eval` a program can easily modify itself in
-even more unforeseeable ways. Therefore pretty much anything in your program
-can actually depend on previous computations performed while the program is
-being executed. To make this work in batch-compiled scripts, the batch
-compiler thus executes the script as usual. The :var:`compiling` variable can
-be used to check whether the script is being batch-compiled, so you can adjust
-to that by selectively enabling or disabling parts of the code. For instance,
-you will usually want to skip execution of the "main program" during batch
-compilation.
-
-.. _partial evaluation: http://en.wikipedia.org/wiki/Partial_evaluation
-
-Last but not least, note that some parts of Pure's metaprogramming
-capabilities and other compile time features are disabled in batch-compiled
-programs:
+Last but not least, some parts of Pure's meta-programming capabilities and
+other compile time features are disabled in batch-compiled programs:
 
 * The :func:`eval` function can only be used to evaluate plain toplevel
   expressions. You can define local functions and variables in :keyword:`with`
@@ -12307,8 +12293,8 @@ programs:
   anything which changes the executing program is "verboten". Moreover, the
   introspective capabilities provided by :func:`evalcmd` and similar
   operations (discussed under Reflection_ in the Macros_ section) are all
-  disabled. If you need any of these capabilities, you have to run your
-  program with the interpreter.
+  disabled. If you need any of these capabilities at run time, you have to run
+  your program with the interpreter.
 
 * Constant and macro definitions, being compile time features, aren't
   available in the compiled program. If you need to use these with
@@ -12320,31 +12306,31 @@ programs:
   pragma can be used to avoid this, see `Options Affecting Code
   Size`_ below.)
 
-* Code which gets executed to compute constant values at compile time will
-  generally *not* be executed in the compiled executable, so your program
-  shouldn't rely on side-effects of such computations (this would be bad
-  practice anyway). There is an exception to this rule, however, namely if a
-  constant value contains run time data such as pointers and local functions
-  which requires an initialization at run time, then the batch compiler will
-  generate code for that. (The same happens if the :option:`--noconst` option
-  is used to force computation of constant values at run time, see `Options
-  Affecting Code Size`_.)
-
 What this boils down to is that in the batch-compiled program you will have to
 avoid anything which requires the compile time or interactive facilities of
-the interpreter. These restrictions only apply at run time, of course. At
-compile time the program *is* being executed by the full version of the
-interpreter so you can use :func:`eval` and :func:`evalcmd` in any desired
-way.
+the interpreter. These restrictions only apply at run time, of course. During
+batch compilation the program *is* being executed by the interpreter, so you
+can use :func:`eval` and :func:`evalcmd` in any desired way. You just need to
+make sure that the corresponding code actually gets executed at compile time
+(remember that plain toplevel expressions aren't). This can be done most
+conveniently by wrapping it up in a :keyword:`const` or :keyword:`let`
+construct, omitting the left-hand side (cf. `Simple Rules`_)::
 
-For most kinds of scripts, the above restrictions aren't really that much of
-an obstacle, or can easily be worked around. For the few scripts which
-actually need the full dynamic capabilities of Pure you'll just have to run
-the script with the interpreter. This isn't a big deal either, only the
-startup will be somewhat slower because the script is compiled on the
-fly. Once the JIT has done its thing the "interpreted" script will run every
-bit as fast as the "compiled" one, since in fact *both* are compiled (only at
-different times) to exactly the same code!
+  const eval "fancy compile time code goes here";
+
+The same approach works with the other inspection operations discussed in
+Reflection_, and also comes in handy if external C code requires
+initialization at compile time. In some cases it may be necessary to execute
+the same code *both* at compile and at run time, which can be achieved by
+using ``let`` in lieu of ``const``.
+
+Most kinds of scripts will work fine when batch-compiled, using the tricks we
+discussed above to work around the little kinks and limitations. For the few
+scripts which actually need the full dynamic capabilities of Pure you'll just
+have to run the script with the interpreter, which shouldn't usually be a big
+impediment either. Once the JIT has done its thing the "interpreted" script
+will run every bit as fast as the "compiled" one, since in fact *both* are
+compiled (only at different times) to exactly the same code!
 
 Example
 -------
@@ -12388,21 +12374,14 @@ desired output file name::
   [1,2,6,24,120,720,5040,40320,362880,3628800]
 
 Next suppose that we'd like to supply the value ``n`` at *compile* rather than
-run time. To these ends we want to turn the value passed to the ``main``
-function into a compile time constant, which can be done as follows::
+run time. This is what `partial evaluation`_ is all about. In Pure we can just
+turn the value passed to the ``main`` function into a compile time constant as
+follows::
 
   const n = if argc>1 then sscanf (argv!1) "%d" else 10;
 
 (Note that we provide ``10`` as a default if ``n`` isn't specified on the
 command line.)
-
-Moreover, in such a case we usually want to skip the execution of the main
-function at compile time. To these ends, the predefined :var:`compiling`
-variable holds a truth value indicating whether the program is actually
-running under the auspices of the batch compiler, so that it can adjust
-accordingly. In our example, the evaluation of ``main`` becomes::
-
-  if compiling then () else main n;
 
 Our program now looks as follows::
 
@@ -12413,7 +12392,7 @@ Our program now looks as follows::
   main n = do puts ["Hello, world!", str (map fact (1..n))];
 
   const n = if argc>1 then sscanf (argv!1) "%d" else 10;
-  if compiling then () else main n;
+  main n;
 
 This script "specializes" ``n`` to the first (compile time) parameter when
 being batch-compiled, and it still works as before when we run it through the
@@ -12438,26 +12417,27 @@ interpreter in both batch and interactive mode, too::
   Hello, world!
   [1,2,6,24,120,720,5040]
 
-In addition, there's also a *compile time* check analogous to the
-:var:`compiling` variable, which indicates whether the source script is being
-run normally or in a batch compilation; see `Conditional Compilation`_. We
-might employ this as follows, replacing the last line of the script with
-this::
+Finally, there's also a compile time check which comes in handy if we want to
+execute different code depending on whether a script is batch-compiled or not;
+see `Conditional Compilation`_. We might employ this as follows, replacing the
+last line of the script with this::
 
   #! --if compiled
-  if compiling then () else main n;
+  if argc>1 then main (sscanf (argv!1) "%d") else main n;
   #! --else
   if argc>1 then main n else puts "Try 'main n' where n is a number.";
   #! --endif
 
-The code in the ``--if compiled`` section, which is the same as before, is now
-only executed during batch compilation and in the compiled executable. If we
-run the script normally, in the interpreter, the code in the ``--else``
-section, which just prints a welcome message if no arguments are given on the
-command line, is executed instead. So we now actually have *four* different
-code paths, depending on whether the script is run normally, with or without
-arguments, or in a batch compilation, or as a native executable. This kind of
-setup is useful if the script is to be run both interactively and
+The code in the ``--if compiled`` section is only executed in the compiled
+script. It now also checks whether there is a parameter specified on the
+command line at run time, using that as the value of ``n`` if present, and
+falling back to the static ``n`` value (specified on the command line during
+compilation, or 10 by default) otherwise. If we run the script normally, in
+the interpreter, the code in the ``--else`` section is executed instead, which
+just prints a welcome message if no arguments are given on the command line.
+So we now actually have *four* different code paths, depending on whether the
+script is run normally or batch-compiled, with or without arguments. This kind
+of setup is useful if the script is to be run both interactively and
 non-interactively in the interpreter while developing it, but once the script
 is finished it gets compiled and installed as a native executable.
 
@@ -12481,6 +12461,10 @@ is finished it gets compiled and installed as a native executable.
   Hello, world!
   [1,2,6,24,120,720,5040,40320,362880,3628800]
 
+  $ ./hello 8
+  Hello, world!
+  [1,2,6,24,120,720,5040,40320]
+
 You'll rarely need an elaborate setup like this, most of the time something
 like our simple first example will do the trick. But, as you've seen, Pure can
 easily do it.
@@ -12494,15 +12478,15 @@ option, in which case the output code includes *all* functions defined in the
 compiled program, the prelude and any other module imported with a
 :keyword:`using` clause, even if they don't seem to be used anywhere. This
 considerably increases compilation times and makes the compiled executable
-much larger. For instance, on a 64 bit Linux systems with ELF binaries the
-executable of our hello.pure example is about thrice as large:
+much larger. For instance, on my 64 bit Linux systems with ELF binaries the
+executable of our hello.pure example is about twice as large:
 
 .. code-block:: none
 
   $ pure -o hello -c -x hello.pure 7 && ls -l hello
-  -rwxr-xr-x 1 ag users 178484 2010-01-12 06:21 hello
+  -rwxr-xr-x 1 ag ag 337304 Apr 10 19:24 hello
   $ pure -o hello -c -u -x hello.pure 7 && ls -l hello
-  -rwxr-xr-x 1 ag users 541941 2010-01-12 06:21 hello
+  -rwxr-xr-x 1 ag ag 664112 Apr 10 19:24 hello
 
 (Note that even the stripped executable is fairly large when compared to
 compiled C code, as it still contains the symbol table of the entire program,
@@ -12545,16 +12529,16 @@ variable). For instance::
   using system;
   puts $ str $ sum xs;
 
-On my 64 bit Linux system this produces a 187115 bytes executable. Without
-:option:`--noconst` the code becomes almost an order of magnitude larger in
-this case (1788699 bytes). On the other hand, the smaller executable also
-takes a little longer to run since it must first recompute the value of the
-list constant at startup. So you have to consider the tradeoffs in a given
-situation. Usually big executables aren't much of a problem on modern
-operating systems, but if your program contains a lot of big constants then
-this may become an important consideration. However, if a constant value takes
-a long time to compute then you'll be better off with the default behaviour of
-precomputing the value at compile time.
+On my 64 bit Linux system this produces a 240 KB executable. Without
+:option:`--noconst` the code becomes almost an order of magnitude larger (some
+1800 KB). On the other hand, the smaller executable also takes a little longer
+to run since it must first recompute the value of the list constant at
+startup. So you have to consider the tradeoffs in a given situation. Usually
+big executables aren't much of a problem on modern operating systems, but if
+your program contains a lot of big constants then this may become an important
+consideration. However, if a constant value takes a long time to compute then
+you'll be better off with the default behaviour of precomputing the value at
+compile time.
 
 Other Output Code Formats
 -------------------------
@@ -12646,24 +12630,27 @@ this will be good enough, but if it isn't, you can just add options to the
 linker command as needed to pull in additional required libraries.
 
 As this last example shows, you can also create shared libraries from Pure
-modules. However, on some systems (most notably x86_64), this requires that
-you pass the :option:`-fPIC` option when batch-compiling the module, so that
-position-independent code is generated::
+modules. However, on some systems you may have to pass the :option:`-fPIC`
+option when batch-compiling the module, so that position-independent code is
+generated::
 
   $ pure -c -fPIC pure-odbc/examples/menagerie.pure -o menagerie.o
 
-Note that even when building a shared module, you'll have to supply an
-initialization routine which calls ``__pure_main__`` somewhere.
+.. note:: On most systems it shouldn't be necessary to specify :option:`-fPIC`
+   explicitly any more, since the compiler will add that option automatically
+   on platforms known to require it. Also note that even when building a
+   shared module, you'll have to supply an initialization routine which calls
+   ``__pure_main__`` somewhere.
 
-Also note that since Pure doesn't support separate compilation in the present
-implementation, if you create different shared modules like this, each will
-contain their own copy all the required Pure functions from the prelude and
-other imported Pure modules. This becomes a problem when trying to link
-several separate batch-compiled modules into the same executable or library,
-because you'll get many name clashes for routines present in different modules
-(including the ``__pure_main__`` entry point). To prevent this, the batch
-compiler can be invoked with the :option:`--main` option to explicitly set a
-name for the main entry point. For instance::
+Since Pure doesn't support separate compilation in the present implementation,
+if you create different shared modules like this, each will contain their own
+copy of all the required Pure functions from the prelude and other imported
+Pure modules. This becomes a problem when trying to link several separate
+batch-compiled modules into the same executable or library, because you'll get
+many name clashes for routines present in different modules (including the
+``__pure_main__`` entry point). To prevent this, the batch compiler can be
+invoked with the :option:`--main` option to explicitly set a name for the main
+entry point. For instance::
 
   $ pure -c hello.pure -o hello.o --main __hello_main__
 
@@ -12948,6 +12935,18 @@ option; please see `Invoking Pure`_ for details. Pure 0.58 also adds two new
 code generation options :option:`--symbolic` and :option:`--nosymbolic` to set
 the default evaluation mode of global functions; these are discussed in
 `Defined Functions`_ below.
+
+Pure 0.66 fixed the treatment of unary/binary minus in custom namespaces. The
+compiler now handles this by manufacturing a corresponding unary minus
+operator and an accompanying ``neg`` function symbol in the same namespace, so
+that the overloaded ``-`` operator works in exactly the same manner as the
+default one.
+
+Pure 0.68 changed the batch compiler so that plain toplevel expressions are
+not evaluated during batch compilation any more. Thus the :var:`compiling`
+variable is obsolete now. It is still supported for backward compatibility,
+but the compiler will flag it as "deprecated" when run with the :option:`-w
+<pure -w>` option. Please check `Batch Compilation`_ for details.
 
 Error Recovery
 --------------


### PR DESCRIPTION
As discussed on the mailing list. The batch compiler now doesn't execute plain toplevel expressions at compile time any more, which makes writing batch-compiled scripts much more straightforward. The `compiling` variable is still supported for backward compatibility, so most existing scripts should continue to work unchanged, but the compiler flags it as "deprecated" now if warnings are enabled (`-w`).