### PR TITLE
acinclude.m4: Use return instead of exit

### DIFF
--- a/pure/acinclude.m4
+++ b/pure/acinclude.m4
@@ -258,7 +258,7 @@ main()
   set_signal_handler(SIGINT, sigint);
   kill((int)getpid(), SIGINT);
   kill((int)getpid(), SIGINT);
-  exit(nsigint != 2);
+  return (nsigint != 2);
 }
 ], q_cv_must_reinstall_sighandlers=no, q_cv_must_reinstall_sighandlers=yes,
 if test "$q_cv_signal_vintage" = svr3; then


### PR DESCRIPTION
On macOS with the clang compiler from Xcode 12 or later, the configure script gets the wrong answer when checking if signal handlers must be reinstalled when invoked because the test uses `exit` without including stdlib.h where it's defined. Clang in Xcode 12 and later considers implicit declaration of function to be an error. Fix it by using `return` instead of `exit`.