### PR TITLE
pure-stllib: find libpure.so under a non-standard prefix

### DIFF
--- a/pure-stllib/check_script
+++ b/pure-stllib/check_script
@@ -7,10 +7,12 @@ DESTDIR=$1
 libdir=`pkg-config pure --variable libdir`
 installdir=${DESTDIR}${libdir}/pure
 
-# Linux might need this
-export LD_LIBRARY_PATH=${installdir}
+# Linux might need this. Include both the module install dir (for the
+# freshly-built .so modules) and the runtime libdir (for libpure.so),
+# so this works when Pure is installed to a non-standard prefix.
+export LD_LIBRARY_PATH=${installdir}:${DESTDIR}${libdir}:${libdir}:${LD_LIBRARY_PATH}
 # OS X needs this
-export DYLD_LIBRARY_PATH=${installdir}
+export DYLD_LIBRARY_PATH=${installdir}:${DESTDIR}${libdir}:${libdir}:${DYLD_LIBRARY_PATH}
 
 curdir=$PWD
 


### PR DESCRIPTION
`pure-stllib/check_script` sets `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH` to only
the module install directory, so the test harness cannot find `libpure.so`
when Pure is installed to a non-standard prefix. Append the runtime libdir
(and preserve any pre-existing value) so the checks run regardless of prefix.
